### PR TITLE
feat: setup moduletemplate cache

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/kyma-project/kyma-operator/operator/pkg/release/template"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"os"
@@ -91,9 +92,10 @@ func main() {
 	}
 
 	if err = (&controllers.KymaReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("kyma-operator"),
+		TemplateCache: template.NewInMemoryCache(),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("kyma-operator"),
 	}).SetupWithManager(setupLog, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Kyma")
 		os.Exit(1)

--- a/operator/pkg/client/listers/operator.kyma-project.io/v1alpha1/moduletemplate.go
+++ b/operator/pkg/client/listers/operator.kyma-project.io/v1alpha1/moduletemplate.go
@@ -92,7 +92,7 @@ func (s moduleTemplateNamespaceLister) Get(name string) (*v1alpha1.ModuleTemplat
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(v1alpha1.Resource("moduletemplate"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("template"), name)
 	}
 	return obj.(*v1alpha1.ModuleTemplate), nil
 }

--- a/operator/pkg/release/template/cache.go
+++ b/operator/pkg/release/template/cache.go
@@ -1,0 +1,43 @@
+package template
+
+import "github.com/pkg/errors"
+
+type Cache interface {
+	Get(key interface{}) (*LookupResult, error)
+	Put(key interface{}, value *LookupResult) error
+	Delete(key interface{}) error
+}
+
+func NewInMemoryCache() Cache {
+	return &inMemoryCache{backingCache: map[string]*LookupResult{}}
+}
+
+type inMemoryCache struct {
+	backingCache LookupResultsByName
+}
+
+func (i *inMemoryCache) Get(key interface{}) (*LookupResult, error) {
+	k, ok := key.(string)
+	if !ok {
+		return nil, errors.Errorf("template with key %s does not exist", k)
+	}
+	return i.backingCache[k], nil
+}
+
+func (i *inMemoryCache) Put(key interface{}, value *LookupResult) error {
+	k, ok := key.(string)
+	if !ok {
+		return errors.Errorf("template with key %s could not be saved to cache", k)
+	}
+	i.backingCache[k] = value
+	return nil
+}
+
+func (i *inMemoryCache) Delete(key interface{}) error {
+	k, ok := key.(string)
+	if !ok {
+		return errors.Errorf("template with key %s could not be deleted", k)
+	}
+	i.backingCache[k] = nil
+	return nil
+}

--- a/operator/pkg/release/template/cached_channel_template.go
+++ b/operator/pkg/release/template/cached_channel_template.go
@@ -1,0 +1,47 @@
+package template
+
+import (
+	"context"
+	operatorv1alpha1 "github.com/kyma-project/kyma-operator/operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewCachedChannelBasedFinder(
+	client client.Reader,
+	component operatorv1alpha1.ComponentType,
+	channel operatorv1alpha1.Channel,
+	cache Cache,
+) Finder {
+	return &cachedChannelBasedFinder{
+		channelBasedFinder: &channelBasedFinder{
+			reader:    client,
+			component: component,
+			channel:   channel,
+		},
+		cache: cache,
+	}
+}
+
+type cachedChannelBasedFinder struct {
+	channelBasedFinder *channelBasedFinder
+	cache              Cache
+}
+
+func (c *cachedChannelBasedFinder) Lookup(ctx context.Context) (*LookupResult, error) {
+	v, err := c.cache.Get(GetTemplateCacheKey(c.channelBasedFinder.component.Name, c.channelBasedFinder.channel))
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		lookupResult, err := c.channelBasedFinder.Lookup(ctx)
+		if lookupResult == nil {
+			return nil, err
+		}
+		if err := c.cache.Put(GetTemplateCacheKey(c.channelBasedFinder.component.Name, c.channelBasedFinder.channel), lookupResult); err != nil {
+			return nil, err
+		}
+		return lookupResult, nil
+	} else {
+		return v, nil
+	}
+}

--- a/operator/pkg/release/template/channel_template.go
+++ b/operator/pkg/release/template/channel_template.go
@@ -1,0 +1,85 @@
+package template
+
+import (
+	"context"
+	"fmt"
+	operatorv1alpha1 "github.com/kyma-project/kyma-operator/operator/api/v1alpha1"
+	"github.com/kyma-project/kyma-operator/operator/pkg/index"
+	"github.com/kyma-project/kyma-operator/operator/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type channelBasedFinder struct {
+	reader    client.Reader
+	component operatorv1alpha1.ComponentType
+	channel   operatorv1alpha1.Channel
+}
+
+func (c *channelBasedFinder) Lookup(ctx context.Context) (*LookupResult, error) {
+	templateList := &operatorv1alpha1.ModuleTemplateList{}
+
+	var desiredChannel operatorv1alpha1.Channel
+
+	if c.component.Channel != "" {
+		// if component channel is set it takes precedence
+		desiredChannel = c.component.Channel
+	} else if c.channel != "" {
+		// else if the global channel is set it takes precedence
+		desiredChannel = c.channel
+	} else {
+		// else use the default channel
+		desiredChannel = operatorv1alpha1.DefaultChannel
+	}
+
+	if err := c.reader.List(ctx, templateList,
+		client.MatchingLabels{
+			labels.ControllerName: c.component.Name,
+		},
+		index.TemplateChannelField.WithValue(string(desiredChannel)),
+	); err != nil {
+		return nil, err
+	}
+
+	if len(templateList.Items) > 1 {
+		return nil, MoreThanOneTemplateCandidateErr(c.component, templateList.Items)
+	}
+
+	// if the desiredChannel cannot be found, use the next best available
+	if len(templateList.Items) == 0 {
+		if err := c.reader.List(ctx, templateList,
+			client.MatchingLabels{
+				labels.ControllerName: c.component.Name,
+			},
+		); err != nil {
+			return nil, err
+		}
+
+		if len(templateList.Items) > 1 {
+			return nil, MoreThanOneTemplateCandidateErr(c.component, templateList.Items)
+		}
+
+		if len(templateList.Items) == 0 {
+			return nil, fmt.Errorf("no config map template found for component: %s", c.component.Name)
+		}
+
+	}
+
+	actualChannel := templateList.Items[0].Spec.Channel
+
+	// if the found configMap has no channel assigned to it set a sensible log output
+	if actualChannel == "" {
+		return nil, fmt.Errorf("no channel found on template for component: %s, specifying no channel is not allowed", c.component.Name)
+	}
+
+	if actualChannel != c.channel {
+		log.FromContext(ctx).V(3).Info(fmt.Sprintf("using %s (instead of %s) for component %s", actualChannel, c.channel, c.component.Name))
+	} else {
+		log.FromContext(ctx).V(3).Info(fmt.Sprintf("using %s for component %s", actualChannel, c.component.Name))
+	}
+
+	return &LookupResult{
+		Template:   &templateList.Items[0],
+		forChannel: &actualChannel,
+	}, nil
+}

--- a/operator/pkg/release/template/template.go
+++ b/operator/pkg/release/template/template.go
@@ -1,0 +1,86 @@
+package template
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	operatorv1alpha1 "github.com/kyma-project/kyma-operator/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Finder interface {
+	Lookup(ctx context.Context) (*LookupResult, error)
+}
+
+type LookupResult struct {
+	Template   *operatorv1alpha1.ModuleTemplate
+	forChannel *operatorv1alpha1.Channel
+}
+
+type LookupResultsByName map[string]*LookupResult
+
+func GetTemplates(ctx context.Context, c client.Reader, k *operatorv1alpha1.Kyma, cache Cache) (LookupResultsByName, error) {
+	templates := make(LookupResultsByName)
+	for _, component := range k.Spec.Components {
+		template, err := NewCachedChannelBasedFinder(c, component, k.Spec.Channel, cache).Lookup(ctx)
+		if err != nil {
+			return nil, err
+		}
+		templates[component.Name] = template
+	}
+	return templates, nil
+}
+
+func AreTemplatesOutdated(logger *logr.Logger, k *operatorv1alpha1.Kyma, templates LookupResultsByName) bool {
+	// this is a shortcut as we already know templates are outdated when the generation changes
+	if k.GetGeneration() != k.Status.ObservedGeneration {
+		logger.Info("new kyma spec, setting template status outdated")
+		return true
+	}
+	// in the case that the kyma spec did not change, we only have to verify that all desired templates are still referenced in the latest spec generation
+	for componentName, lookupResult := range templates {
+		for _, condition := range k.Status.Conditions {
+			if condition.Reason == componentName && lookupResult != nil {
+				if lookupResult.Template.GetGeneration() != condition.TemplateInfo.Generation || lookupResult.Template.Spec.Channel != condition.TemplateInfo.Channel {
+					logger.Info("detected outdated template",
+						"condition", condition.Reason,
+						"template", lookupResult.Template.Name,
+						"templateGeneration", lookupResult.Template.GetGeneration(),
+						"previousGeneration", condition.TemplateInfo.Generation,
+						"templateChannel", lookupResult.Template.Spec.Channel,
+						"previousChannel", condition.TemplateInfo.Channel,
+					)
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func MoreThanOneTemplateCandidateErr(component operatorv1alpha1.ComponentType, candidateTemplates []operatorv1alpha1.ModuleTemplate) error {
+	candidates := make([]string, len(candidateTemplates))
+	for i, candidate := range candidateTemplates {
+		candidates[i] = candidate.GetName()
+	}
+	return fmt.Errorf("more than one config map template found for component: %s, candidates: %v", component.Name, candidates)
+}
+
+func GetTemplateCacheKey(module string, channel operatorv1alpha1.Channel) string {
+	return fmt.Sprintf("%s/%s", module, channel)
+}
+
+func GetUnstructuredComponentFromTemplate(templates LookupResultsByName, componentName string, kyma *operatorv1alpha1.Kyma) (*unstructured.Unstructured, error) {
+	lookupResult := templates[componentName]
+	if lookupResult == nil {
+		return nil, fmt.Errorf("could not find template %s for resource %s",
+			componentName, client.ObjectKeyFromObject(kyma))
+	}
+
+	desiredComponentStruct := &lookupResult.Template.Spec.Data
+	desiredComponentStruct.SetName(componentName + kyma.Name)
+	desiredComponentStruct.SetNamespace(kyma.GetNamespace())
+
+	return desiredComponentStruct.DeepCopy(), nil
+}

--- a/operator/pkg/util/kyma_util.go
+++ b/operator/pkg/util/kyma_util.go
@@ -1,12 +1,9 @@
 package util
 
 import (
-	"fmt"
 	operatorv1alpha1 "github.com/kyma-project/kyma-operator/operator/api/v1alpha1"
 	"github.com/kyma-project/kyma-operator/operator/pkg/labels"
-	"github.com/kyma-project/kyma-operator/operator/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ComponentsAssociatedWithTemplate struct {
@@ -37,18 +34,4 @@ func CopyComponentSettingsToUnstructuredFromResource(resource *unstructured.Unst
 		}
 		resource.Object["spec"].(map[string]interface{})["charts"] = charts
 	}
-}
-
-func GetUnstructuredComponentFromTemplate(templates release.TemplateLookupResultsByName, componentName string, kyma *operatorv1alpha1.Kyma) (*unstructured.Unstructured, error) {
-	lookupResult := templates[componentName]
-	if lookupResult == nil {
-		return nil, fmt.Errorf("could not find template %s for resource %s",
-			componentName, client.ObjectKeyFromObject(kyma))
-	}
-
-	desiredComponentStruct := &lookupResult.Template.Spec.Data
-	desiredComponentStruct.SetName(componentName + kyma.Name)
-	desiredComponentStruct.SetNamespace(kyma.GetNamespace())
-
-	return desiredComponentStruct.DeepCopy(), nil
 }


### PR DESCRIPTION
Cache Key is generated from Controller-Name (e.g. manifest) + Channel (stable), as there can be at most one template for this combination. If a module change is detected, the template is purged from the cache and will be dynamically recalculated the next time a kyma is reconciled for this channel. This will happen right after the invalidation since all Kymas connected to the channel with the module will be requeued.