### PR TITLE
fix: allow new conditions during update

### DIFF
--- a/docs/starting-operator-with-webhooks.md
+++ b/docs/starting-operator-with-webhooks.md
@@ -1,0 +1,44 @@
+# Enabling Webhooks in Kyma Operator
+
+To make local testing easier, webhooks are disabled by default. To enable webhooks running with the operator,
+you will have to change some kustomization.yaml files as well as introduce a flag that will enable the webhook server:
+
+
+In `config/crd/kustomization.yaml`:
+
+```yaml
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+- patches/webhook_in_kymas.yaml
+- patches/webhook_in_moduletemplates.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+- patches/cainjection_in_kymas.yaml
+- patches/cainjection_in_moduletemplates.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+```
+
+Next, make sure to enable the webhooks by configuring the `enable-webhooks` flag:
+```go
+flag.BoolVar(&flagVar.enableWebhooks, "enable-webhooks", false,
+    "Enabling Validation/Conversion Webhooks.")
+```
+
+You can do this by updating `config/manager/controller_manager_config.yaml`:
+```yaml
+apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+kind: ControllerManagerConfig
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: 127.0.0.1:8080
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: 893110f7.kyma-project.io
+enableWebhooks: true
+```

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -66,7 +66,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -394,13 +394,10 @@ func (r *KymaReconciler) CreateOrUpdateModules(ctx context.Context, kyma *v1alph
 		}
 
 		// if we have NO create, NO update,the template was NOT outdated and the Condition did not exist yet, then everything is awesome!
-		// Now there can be 2 cases
-		// either the condition was never tracked before, or it was tracked before but isnt ready yet.
 		// we now insert the condition to false as we expect the next step to verify every time if the module is still ready,
 		// by default the module will NOT be ready.
 		status.Helper(r).SyncReadyConditionForModules(kyma, parsed.Modules{name: module}, v1alpha1.ConditionStatusFalse,
 			fmt.Sprintf("module %s was not created or updated", module.Name))
-
 	}
 
 	return false, nil

--- a/operator/controllers/kyma_controller.go
+++ b/operator/controllers/kyma_controller.go
@@ -393,7 +393,7 @@ func (r *KymaReconciler) CreateOrUpdateModules(ctx context.Context, kyma *v1alph
 			}
 		}
 
-		// if we have NO create, NO update,the template was NOT outdated and the Condition did not exist yet, then everything is awesome!
+		// if we have NO create, NO update,the template was NOT outdated and the Condition did not exist yet
 		// we now insert the condition to false as we expect the next step to verify every time if the module is still ready,
 		// by default the module will NOT be ready.
 		status.Helper(r).SyncReadyConditionForModules(kyma, parsed.Modules{name: module}, v1alpha1.ConditionStatusFalse,


### PR DESCRIPTION
This fixes an issue where if the kyma installation failed and the conditions were not all present yet, some conditions will not be present in the update call. this previously resulted in an error case. Now it instead defaults to a not ready condition to allow further processing. It also creates a small doc explaining how to run the operator with webhooks